### PR TITLE
Fix not to die on first path without .current

### DIFF
--- a/src/tools/haxelib/Main.hx
+++ b/src/tools/haxelib/Main.hx
@@ -1341,7 +1341,7 @@ class Main {
 		print("Library "+prj+" current version is now "+version);
 	}
 
-	function checkRec( prj : String, version : String, l : List<{ rep : String, project : String, version : String, info : Infos }> ) {
+	function checkRec( prj : String, requestedVersion : String, l : List<{ rep : String, project : String, version : String, info : Infos }> ) {
 		var reps = getRepositories();
 		var found = false;
 		for (rep in reps) {
@@ -1349,9 +1349,9 @@ class Main {
 			if( !FileSystem.exists(pdir) ) {
 				continue;
 			}
-			var currentVersion;
+			var version;
 			try {
-				currentVersion = version != null ? version : getCurrent(pdir);
+				version = requestedVersion != null ? requestedVersion : getCurrent(pdir);
 			} catch(e:Dynamic) {
 				print("No .current file for haxelib dir " + rep + " for haxelib " + prj);
 				continue;


### PR DESCRIPTION
Sorry, cleaning up the tabs caused more diffs then I wanted.  Ignore whitespace in the diff.   The changes fixes so haxelib path does not die on the first path it finds that does not have a `.current` file.